### PR TITLE
forwarding variable smiles to get_expanded_groups to avoid "variable not found error"

### DIFF
--- a/src/group_search.jl
+++ b/src/group_search.jl
@@ -143,7 +143,7 @@ function _get_groups_from_smiles(smiles::String,groups::Vector{GCPair},connectiv
     atoms = get_atoms(mol)
     natoms = length(atoms)
     __bonds = __getbondlist(mol)
-    group_id_expanded, bond_mat_minimum = get_expanded_groups(mol, groups, atoms, __bonds, check)
+    group_id_expanded, bond_mat_minimum = get_expanded_groups(mol, groups, atoms, __bonds, check, smiles)
 
     group_id = unique(group_id_expanded)
     group_occ_list = [sum(group_id_expanded .== i) for i in group_id]
@@ -236,7 +236,7 @@ function get_connectivity(mol,group_id,groups)
     return connectivity
 end
 
-function get_expanded_groups(mol, groups, atoms, __bonds, check)
+function get_expanded_groups(mol, groups, atoms, __bonds, check, smiles)
     smatches_idx_expanded, bond_mat = find_covered_atoms(mol, groups, atoms, __bonds, check)
     # Find all atoms that are in more than one group
     overlap = findall(sum(bond_mat, dims=1)[:] .> 1)


### PR DESCRIPTION
Running:
`f = get_groups_from_smiles("C1OCOCO1", UNIFACGroups) #1,3,5-trioxane`

Results in:
```
ERROR: UndefVarError: `smiles` not defined
Stacktrace:
 [1] get_expanded_groups(mol::MolecularGraph.SMILESMolGraph, groups::Vector{GCPair}, atoms::UnitRange{Int64}, __bonds::Vector{Tuple{Int64, Int64}}, check::Bool)
   @ GCIdentifier C:\Users\thvt\.julia\packages\GCIdentifier\zQuz2\src\group_search.jl:258
 [2] _get_groups_from_smiles(smiles::String, groups::Vector{GCPair}, connectivity::Bool, check::Bool)
   @ GCIdentifier C:\Users\thvt\.julia\packages\GCIdentifier\zQuz2\src\group_search.jl:146
 [3] get_groups_from_smiles(smiles::String, groups::Vector{GCPair}; connectivity::Bool, check::Bool)
   @ GCIdentifier C:\Users\thvt\.julia\packages\GCIdentifier\zQuz2\src\group_search.jl:112
 [4] get_groups_from_smiles(smiles::String, groups::Vector{GCPair})
   @ GCIdentifier C:\Users\thvt\.julia\packages\GCIdentifier\zQuz2\src\group_search.jl:110
 [5] top-level scope
   @ REPL[163]:1
```

Because the variable `smiles` is not passed on to `get_expanded_groups()`, but the function tries to raise an error that accesses this variable. 

This small PR fixes the issue in the simplest possible way, i.e., by adding the variable smiles as an argument to the get_expanded_groups() function.